### PR TITLE
feat: add time-based ODRL constraints (dayOfWeek, hourOfDay)

### DIFF
--- a/doc/REGO.md
+++ b/doc/REGO.md
@@ -1,47 +1,14 @@
 # REGO Methods
 
 
-## dome
+## vc
 
 | ODRL Class | ODRL Key | Rego-Method | Description |
 | --- | --- | --- | --- |
-| action | dome-op:create | is_creation(request) | Check if the given request is a creation |
-| action | dome-op:set_published | is_set_published(request) | check if the entity is set to published in the request. |
-| leftOperand | dome-op:role | role(verifiable_credential,organization_id) | retrieves the roles from the (lear) credential, that target the current organization |
-| leftOperand | dome-op:currentParty | current_party(credential) | the current (organization)party, |
-| leftOperand | dome-op:relatedParty | related_party(http_part) | get the entity from tm-forum and extract related party |
-| leftOperand | dome-op:owner | owner(related_party) | filter the given list of related_party(ies) for one with role "Owner" |
-| leftOperand | dome-op:relatedParty_role | related_party_role(entity) | return the role from the related party of an entity |
-| leftOperand | dome-op:validFor_endDateTime | valid_for_end_date_time(entity) | return the end of the validity of an entity |
-| leftOperand | dome-op:validFor_startDateTime | valid_for_start_date_time(entity) | return the start of the validity of an entity |
-
-## odrl
-
-| ODRL Class | ODRL Key | Rego-Method | Description |
-| --- | --- | --- | --- |
-| rightOperand | odrl:policyUsage | policy_usage | return the current time in ms, e.g. the time that the policy is used |
-| operand | odrl:and | and_operand(constraints) | checks if all given constraints are true |
-| operand | odrl:andSequence | and_sequence_operand(constraints) | checks if all given constraints are true |
-| operand | odrl:or | or_operand(constraints) | check that at least one of the constraints is true |
-| operand | odrl:xone | only_one_operand(constraints) | check that exactly one of the constraints is true |
-| operator | odrl:eq | eq_operator(leftOperand, | check that both operands are equal |
-| operator | odrl:hasPart | has_part_operator(leftOperand, | check that the rightOperand is in the leftOperand |
-| operator | odrl:gt | gt_operator(leftOperand, | check that the leftOperand is greater than the rightOperand |
-| operator | odrl:gteq | gt_eq_operator(leftOperand, | check that the leftOperand is greater or equal to the rightOperand |
-| operator | odrl:isAllOf | is_all_of_operator(leftOperand, | check that the given sets are equal |
-| operator | odrl:isAnyOf | is_any_of_operator(leftOperand, | check that the leftOperand is contained in the rightOperand set |
-| operator | odrl:isNoneOf | is_none_of_operator(leftOperand, | check that the leftOperand is not contained in the rightOperand set |
-| operator | odrl:isPartOf | is_part_of_operator(leftOperand, | check that the rightOperand is contained in the leftOperand set |
-| operator | odrl:lt | lt_operator(leftOperand, | check that the leftOperand is less than the rightOperand |
-| operator | odrl:lteq | lt_eq_operator(leftOperand, | check that the leftOperand is less or equal to the rightOperand |
-| operator | odrl:neq | n_eq_operator(leftOperand, | check that the operands are unequal |
-| action | odrl:modify | is_modification(request) | checks if the given request is a modification |
-| action | odrl:delete | is_deletion(request) | checks if the given request is a deletion |
-| action | odrl:read | is_read(request) | checks if the given request is a read operation |
-| action | odrl:use | is_use(request) | checks if the given request is a usage |
-| target | odrl:target,odrl:uid | is_target(target, | check that the uid of the target is equal to the given uid |
-| assignee | odrl:uid,odrl:assignee | is_user(user,uid) | is the given user id the same as the given uid |
-| leftOperand | odrl:currentTime | current_time | returns the current time in ms |
+| assignee | odrl:any | is_any | allows for any user |
+| leftOperand | vc:role | role(verifiable_credential,organization_id) | retrieves the roles from the credential, that target the current organization |
+| leftOperand | vc:currentParty | current_party(credential) | the current (organization)party, |
+| leftOperand | vc:type | types(verifiable_credential) | the type(s) of the current credential |
 
 ## gaiax
 
@@ -50,6 +17,20 @@
 | constraint | ovc:constraints | evaluate(constraints) | evaluates all provided constraints |
 | constraint | ovc:credentialSubjectType | credentialSubjectType(verifiable_credential, | compares the credentials' subject-type with the provided one |
 | leftOperand | ovc:leftOperand | getClaim(verifiable_credential, | retrieves the claim from the credential, using the json-path of the claim |
+
+## dome
+
+| ODRL Class | ODRL Key | Rego-Method | Description |
+| --- | --- | --- | --- |
+| leftOperand | dome-op:role | role(verifiable_credential,organization_id) | retrieves the roles from the (lear) credential, that target the current organization |
+| leftOperand | dome-op:currentParty | current_party(credential) | the current (organization)party, |
+| leftOperand | dome-op:relatedParty | related_party(http_part) | get the entity from tm-forum and extract related party |
+| leftOperand | dome-op:owner | owner(related_party) | filter the given list of related_party(ies) for one with role "Owner" |
+| leftOperand | dome-op:relatedParty_role | related_party_role(entity) | return the role from the related party of an entity |
+| leftOperand | dome-op:validFor_endDateTime | valid_for_end_date_time(entity) | return the end of the validity of an entity |
+| leftOperand | dome-op:validFor_startDateTime | valid_for_start_date_time(entity) | return the start of the validity of an entity |
+| action | dome-op:create | is_creation(request) | Check if the given request is a creation |
+| action | dome-op:set_published | is_set_published(request) | check if the entity is set to published in the request. |
 
 ## utils
 
@@ -73,33 +54,54 @@
 
 | ODRL Class | ODRL Key | Rego-Method | Description |
 | --- | --- | --- | --- |
-| action | ngsild:create | is_creation(request) | Check if the given request is a creation |
 | leftOperand | ngsi-ld:entityType | entity_type(http_part) | retrieves the type from an entity, either from the request path or from the body |
 | leftOperand | ngsi-ld:<property> | # | retrieves the value of the property, only applies to properties of type "Property". The method should be concretized in the mapping.json, to match a concrete property. |
 | leftOperand | ngsi-ld:<property>_observedAt | # | retrieves the observedAt of the property The method should be concretized in the mapping.json, to match a concrete property. |
 | leftOperand | ngsi-ld:<property>_modifiedAt | # | retrieves the modifiedAt of the property The method should be concretized in the mapping.json, to match a concrete property. |
 | leftOperand | ngsi-ld:<relationship> | # | retrieves the object of the relationship, only applies to properties of type "Relationship". The method should be concretized in the mapping.json, to match a concrete property. |
-
-## tmf
-
-| ODRL Class | ODRL Key | Rego-Method | Description |
-| --- | --- | --- | --- |
-| action | tmf:create | is_creation(request) | Check if the given request is a creation |
-| leftOperand | tmf:lifecycleStatus | life_cycle_status(entity) | return the lifeCycleStatus of a given entity |
-| leftOperand | tmf:resource | resource_type(http_part) | retrieves the type of the resource from the path |
-
-## vc
-
-| ODRL Class | ODRL Key | Rego-Method | Description |
-| --- | --- | --- | --- |
-| assignee | odrl:any | is_any | allows for any user |
-| leftOperand | vc:role | role(verifiable_credential,organization_id) | retrieves the roles from the credential, that target the current organization |
-| leftOperand | vc:currentParty | current_party(credential) | the current (organization)party, |
-| leftOperand | vc:type | types(verifiable_credential) | the type(s) of the current credential |
+| action | ngsild:create | is_creation(request) | Check if the given request is a creation |
 
 ## http
 
 | ODRL Class | ODRL Key | Rego-Method | Description |
 | --- | --- | --- | --- |
-| operator | http:isInPath | is_in_path_operator(leftOperand, | check that left operand is in the path of the right operand |
 | leftOperand | http:path | path(http_part) | returns the currently requested path |
+| operator | http:isInPath | is_in_path_operator(leftOperand, | check that left operand is in the path of the right operand |
+
+## tmf
+
+| ODRL Class | ODRL Key | Rego-Method | Description |
+| --- | --- | --- | --- |
+| leftOperand | tmf:lifecycleStatus | life_cycle_status(entity) | return the lifeCycleStatus of a given entity |
+| leftOperand | tmf:resource | resource_type(http_part) | retrieves the type of the resource from the path |
+| action | tmf:create | is_creation(request) | Check if the given request is a creation |
+
+## odrl
+
+| ODRL Class | ODRL Key | Rego-Method | Description |
+| --- | --- | --- | --- |
+| assignee | odrl:uid,odrl:assignee | is_user(user,uid) | is the given user id the same as the given uid |
+| leftOperand | odrl:currentTime | current_time | returns the current time in ms |
+| leftOperand | odrl:dayOfWeek | day_of_week(ts) | Day of week from timestamp (0=Mon, 6=Sun) |
+| leftOperand | odrl:hourOfDay | hour_of_day(ts) | Hour of day (UTC) from timestamp (0–23) |
+| operand | odrl:and | and_operand(constraints) | checks if all given constraints are true |
+| operand | odrl:andSequence | and_sequence_operand(constraints) | checks if all given constraints are true |
+| operand | odrl:or | or_operand(constraints) | check that at least one of the constraints is true |
+| operand | odrl:xone | only_one_operand(constraints) | check that exactly one of the constraints is true |
+| rightOperand | odrl:policyUsage | policy_usage | return the current time in ms, e.g. the time that the policy is used |
+| operator | odrl:eq | eq_operator(leftOperand, | check that both operands are equal |
+| operator | odrl:hasPart | has_part_operator(leftOperand, | check that the rightOperand is in the leftOperand |
+| operator | odrl:gt | gt_operator(leftOperand, | check that the leftOperand is greater than the rightOperand |
+| operator | odrl:gteq | gt_eq_operator(leftOperand, | check that the leftOperand is greater or equal to the rightOperand |
+| operator | odrl:isAllOf | is_all_of_operator(leftOperand, | check that the given sets are equal |
+| operator | odrl:isAnyOf | is_any_of_operator(leftOperand, | check that the leftOperand is contained in the rightOperand set |
+| operator | odrl:isNoneOf | is_none_of_operator(leftOperand, | check that the leftOperand is not contained in the rightOperand set |
+| operator | odrl:isPartOf | is_part_of_operator(leftOperand, | check that the rightOperand is contained in the leftOperand set |
+| operator | odrl:lt | lt_operator(leftOperand, | check that the leftOperand is less than the rightOperand |
+| operator | odrl:lteq | lt_eq_operator(leftOperand, | check that the leftOperand is less or equal to the rightOperand |
+| operator | odrl:neq | n_eq_operator(leftOperand, | check that the operands are unequal |
+| target | odrl:target,odrl:uid | is_target(target, | check that the uid of the target is equal to the given uid |
+| action | odrl:modify | is_modification(request) | checks if the given request is a modification |
+| action | odrl:delete | is_deletion(request) | checks if the given request is a deletion |
+| action | odrl:read | is_read(request) | checks if the given request is a read operation |
+| action | odrl:use | is_use(request) | checks if the given request is a usage |

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -176,6 +176,14 @@
       "dateTime": {
         "regoPackage": "odrl.leftOperand as odrl_lo",
         "regoMethod": "odrl_lo.current_time"
+      },
+      "dayOfWeek": {
+        "regoPackage": "odrl.leftOperand as odrl_lo",
+        "regoMethod": "odrl_lo.day_of_week(odrl_lo.current_time)"
+      },
+      "hourOfDay": {
+        "regoPackage": "odrl.leftOperand as odrl_lo",
+        "regoMethod": "odrl_lo.hour_of_day(odrl_lo.current_time)"
       }
     },
     "dome-op": {

--- a/src/main/resources/rego/odrl/leftOperand.rego
+++ b/src/main/resources/rego/odrl/leftOperand.rego
@@ -5,3 +5,18 @@ import rego.v1
 ## odrl:currentTime
 # returns the current time in ms
 current_time := time.now_ns() / 1000000
+
+## odrl:dayOfWeek
+# Day of week from timestamp (0=Mon, 6=Sun)
+day_of_week(ts) = weekday if {
+  days := floor(ts / 1000 / 86400)
+  weekday := (days + 4) % 7
+}
+
+## odrl:hourOfDay
+# Hour of day (UTC) from timestamp (0–23)
+hour_of_day(ts) = hour if {
+  seconds := floor(ts / 1000)
+  seconds_in_day := seconds % 86400
+  hour := floor(seconds_in_day / 3600)
+}

--- a/src/test/resources/examples/odrl/3000/3000.rego
+++ b/src/test/resources/examples/odrl/3000/3000.rego
@@ -1,0 +1,17 @@
+package policy.weekday_hours_cars
+
+import data.odrl.operand as odrl_operand
+import data.odrl.action as odrl_action
+import data.utils.helper as helper
+import data.odrl.leftOperand as odrl_lo
+import data.ngsild.leftOperand as ngsild_lo
+import rego.v1
+import data.odrl.operator as odrl_operator
+import data.vc.assignee as vc_assignee
+
+is_allowed if {
+odrl_action.is_read(helper.http_part)
+odrl_operand.and_sequence_operand([odrl_operator.eq_operator(ngsild_lo.entity_type(helper.http_part),"Test_Car")])
+vc_assignee.is_any
+odrl_operand.and_sequence_operand([odrl_operator.gt_eq_operator(odrl_lo.day_of_week(odrl_lo.current_time),0),odrl_operator.lt_eq_operator(odrl_lo.day_of_week(odrl_lo.current_time),4),odrl_operator.gt_eq_operator(odrl_lo.hour_of_day(odrl_lo.current_time),8),odrl_operator.lt_eq_operator(odrl_lo.hour_of_day(odrl_lo.current_time),23)])
+}

--- a/src/test/resources/examples/odrl/3000/_3000.json
+++ b/src/test/resources/examples/odrl/3000/_3000.json
@@ -1,0 +1,66 @@
+{
+  "@context": {
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "ngsi-ld": "https://uri.etsi.org/ngsi-ld/"
+  },
+  "@type": "odrl:Policy",
+  "odrl:permission": {
+    "odrl:assigner": {
+      "@id": "https://www.mp-operation.org/"
+    },
+    "odrl:assignee": {
+      "@id": "vc:any"
+    },
+    "odrl:action": {
+      "@id": "odrl:read"
+    },
+    "odrl:target": {
+      "@type": "odrl:AssetCollection",
+      "odrl:source": "urn:asset",
+      "odrl:refinement": [
+        {
+          "@type": "odrl:Constraint",
+          "odrl:leftOperand": "ngsi-ld:entityType",
+          "odrl:operator": {
+            "@id": "odrl:eq"
+          },
+          "odrl:rightOperand": "Test_Car"
+        }
+      ]
+    },
+    "odrl:constraint": [
+      {
+        "odrl:leftOperand": "odrl:dayOfWeek",
+        "odrl:operator": "odrl:gteq",
+        "odrl:rightOperand": {
+          "@value": 0,
+          "@type": "xsd:integer"
+        }
+      },
+      {
+        "odrl:leftOperand": "odrl:dayOfWeek",
+        "odrl:operator": "odrl:lteq",
+        "odrl:rightOperand": {
+          "@value": 4,
+          "@type": "xsd:integer"
+        }
+      },
+      {
+        "odrl:leftOperand": "odrl:hourOfDay",
+        "odrl:operator": "odrl:gteq",
+        "odrl:rightOperand": {
+          "@value": 8,
+          "@type": "xsd:integer"
+        }
+      },
+      {
+        "odrl:leftOperand": "odrl:hourOfDay",
+        "odrl:operator": "odrl:lteq",
+        "odrl:rightOperand": {
+          "@value": 23,
+          "@type": "xsd:integer"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Feature: Add Time-Based ODRL Constraints (odrl:dayOfWeek and odrl:hourOfDay)

This PR introduces support for temporal access constraints in ODRL policies, enabling dynamic time-based policy evaluation using two new left operands evaluated at runtime.

## New Left Operands

- **`odrl:dayOfWeek`**: Returns the current weekday in UTC → 0 = Monday, ..., 6 = Sunday
- **`odrl:hourOfDay`**: Returns the current hour in UTC → Range: 0–23

## Implementation Details

### Modified Files

- `src/main/resources/rego/odrl/leftOperand.rego` → Added time-based operand functions
- `src/main/resources/mapping.json` → Registered both new operands

### New Functions in `odrl.leftOperand.rego`

```rego
## odrl:dayOfWeek
# Day of week from current time (0=Mon, 6=Sun)
day_of_week(current_time) = weekday {
  ts := current_time
  days := floor(ts / 1000 / 86400)
  weekday := (days + 4) % 7
}

## odrl:hourOfDay  
# Hour of day (UTC) from current time (0–23)
hour_of_day(current_time) = hour {
  ts := current_time
  seconds := floor(ts / 1000)
  seconds_in_day := seconds % 86400
  hour := floor(seconds_in_day / 3600)
}
```

### Registered in `mapping.json`

```json
{
  "dayOfWeek": {
    "regoPackage": "odrl.leftOperand as odrl_lo",
    "regoMethod": "odrl_lo.day_of_week(current_time)"
  },
  "hourOfDay": {
    "regoPackage": "odrl.leftOperand as odrl_lo",
    "regoMethod": "odrl_lo.hour_of_day(current_time)"
  }
}
```

## Use Cases

This enables expressive time-based access control, such as:

- Restricting access to working hours only
- Defining weekend-only or night-time rules
- Aligning access to time-sensitive operations
- Enabling scheduled API availability

## Example Combinations

### Weekends (Saturday–Sunday)

```json
[
  {
    "odrl:leftOperand": "odrl:dayOfWeek",
    "odrl:operator": "odrl:gteq",
    "odrl:rightOperand": { "@value": 5, "@type": "xsd:integer" }
  },
  {
    "odrl:leftOperand": "odrl:dayOfWeek",
    "odrl:operator": "odrl:lteq",
    "odrl:rightOperand": { "@value": 6, "@type": "xsd:integer" }
  }
]
```

### Night hours (20:00–23:00 UTC)

```json
[
  {
    "odrl:leftOperand": "odrl:hourOfDay",
    "odrl:operator": "odrl:gteq",
    "odrl:rightOperand": { "@value": 20, "@type": "xsd:integer" }
  },
  {
    "odrl:leftOperand": "odrl:hourOfDay",
    "odrl:operator": "odrl:lteq",
    "odrl:rightOperand": { "@value": 23, "@type": "xsd:integer" }
  }
]
```

## Example Policy: weekday_hours_cars

This policy allows access to Test_Car entities only Monday–Friday between 08:00–23:00 UTC.

### Load Policy

```bash
curl -X PUT http://localhost:8081/policy/weekday_hours_cars \
-H "Content-Type: application/json" \
-d '{
	"@context": {
		"odrl": "http://www.w3.org/ns/odrl/2/",
		"ngsi-ld": "https://uri.etsi.org/ngsi-ld/"
	},
	"@type": "odrl:Policy",
	"odrl:permission": {
		"odrl:assigner": { "@id": "https://www.mp-operation.org/" },
		"odrl:assignee": { "@id": "vc:any" },
		"odrl:action": { "@id": "odrl:read" },
		"odrl:target": {
			"@type": "odrl:AssetCollection",
			"odrl:source": "urn:asset",
			"odrl:refinement": [{
				"@type": "odrl:Constraint",
				"odrl:leftOperand": "ngsi-ld:entityType",
				"odrl:operator": { "@id": "odrl:eq" },
				"odrl:rightOperand": "Test_Car"
			}]
		},
		"odrl:constraint": [
			{
				"odrl:leftOperand": "odrl:dayOfWeek",
				"odrl:operator": "odrl:gteq",
				"odrl:rightOperand": { "@value": 0, "@type": "xsd:integer" }
			},
			{
				"odrl:leftOperand": "odrl:dayOfWeek",
				"odrl:operator": "odrl:lteq",
				"odrl:rightOperand": { "@value": 4, "@type": "xsd:integer" }
			},
			{
				"odrl:leftOperand": "odrl:hourOfDay",
				"odrl:operator": "odrl:gteq",
				"odrl:rightOperand": { "@value": 8, "@type": "xsd:integer" }
			},
			{
				"odrl:leftOperand": "odrl:hourOfDay",
				"odrl:operator": "odrl:lteq",
				"odrl:rightOperand": { "@value": 23, "@type": "xsd:integer" }
			}
		]
	}
}'
```

### Test Policy Evaluation

```bash
curl -X POST http://localhost:8181/ \
-H "Content-Type: application/json" \
-d '{
	"request": {
		"method": "GET",
		"path": "/ngsi-ld/v1/entities",
		"query": {
			"type": "Test_Car"
		},
		"headers": {}
	}
}'
```

### Expected Results

- **`true`** → if executed Monday–Friday, 08:00–23:00 UTC
- **`false`** → otherwise

## Technical Notes

- All evaluations use UTC timestamps
- Compatible with all standard ODRL operators (eq, gteq, lteq, hasPart, etc.)
- Weekdays are zero-based: 0 = Monday, 6 = Sunday
- Hours follow 24h format: 0 = midnight, 23 = 11PM

## Related

This implementation addresses the need for temporal constraints mentioned in ODRL specification and provides a foundation for more complex time-based policies in data spaces and marketplace scenarios.