### PR TITLE
feat(ngsi-ld): add entityTypeGroup leftOperand for multi-entity type policies

### DIFF
--- a/doc/REGO.md
+++ b/doc/REGO.md
@@ -59,6 +59,7 @@
 | leftOperand | ngsi-ld:<property>_observedAt | # | retrieves the observedAt of the property The method should be concretized in the mapping.json, to match a concrete property. |
 | leftOperand | ngsi-ld:<property>_modifiedAt | # | retrieves the modifiedAt of the property The method should be concretized in the mapping.json, to match a concrete property. |
 | leftOperand | ngsi-ld:<relationship> | # | retrieves the object of the relationship, only applies to properties of type "Relationship". The method should be concretized in the mapping.json, to match a concrete property. |
+| leftOperand | ngsi-ld:entityTypeGroup | entity_type_group(http_part) | returns the entity type - let the operator do the comparison |
 | action | ngsild:create | is_creation(request) | Check if the given request is a creation |
 
 ## http

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -170,6 +170,10 @@
       "entityType": {
         "regoPackage": "ngsild.leftOperand as ngsild_lo",
         "regoMethod": "ngsild_lo.entity_type(helper.http_part)"
+      },
+      "entityTypeGroup": {
+        "regoPackage": "ngsild.leftOperand as ngsild_lo",
+        "regoMethod": "ngsild_lo.entity_type_group(helper.http_part)"
       }
     },
     "odrl": {

--- a/src/main/resources/rego/ngsi-ld/leftOperand.rego
+++ b/src/main/resources/rego/ngsi-ld/leftOperand.rego
@@ -43,3 +43,6 @@ property_observed_at(property_name,body) := body[property_name].modifiedAt
 # F.e.: ngsi-ld:owningCompany = relationship_object("owningCompany", http_part.body)
 relationship_object(relationship_name, body):= body[relationship_name].object
 
+## ngsi-ld:entityTypeGroup
+# returns the entity type - let the operator do the comparison
+entity_type_group(http_part) := entity_type(http_part)


### PR DESCRIPTION
# Feature: Add NGSI-LD Entity Type Group Support (ngsi-ld:entityTypeGroup)

This PR introduces support for entity type group constraints in ODRL policies, enabling access control for multiple NGSI-LD entity types using a single constraint. This functionality was not feasible using existing operators, due to the lack of support for array-based constraints like `odrl:isAnyOf`.

## New Left Operand

**`ngsi-ld:entityTypeGroup`**: Returns the entity type from NGSI-LD requests and enables group-based type validation using array operators.

## Implementation Details

### Modified Files
- `src/main/resources/rego/ngsild/leftOperand.rego` → Added entity type group operand function
- `src/main/resources/mapping.json` → Registered the new operand

### New Function in ngsild.leftOperand.rego

```rego
## ngsi-ld:entityTypeGroup
# returns the entity type - let the operator do the comparison
entity_type_group(http_part) := entity_type(http_part)
```

The function `entity_type_group` simply returns the entity type. The actual group validation is handled by operators like `odrl:isAnyOf`, which compare the return value to the array specified in `odrl:rightOperand`.

This function leverages the existing `entity_type` function which extracts entity types from:
- **Path**: `/entities/urn:ngsi-ld:Schedule:123` → "Schedule"
- **Body**: `{"type": "Schedule", ...}` → "Schedule"  
- **Query**: `?type=Schedule` → "Schedule"

### Registered in mapping.json

```json
{
  "entityTypeGroup": {
    "regoPackage": "ngsild.leftOperand as ngsild_lo",
    "regoMethod": "ngsild_lo.entity_type_group(helper.http_part)"
  }
}
```

## Use Cases

This enables new functionality for entity type access control:

- **Multi-entity operations**: Single constraint for multiple entity types
- **Simplified policy management**: Group-based access control in one constraint

## Problem Solved

### Before: Impossible to Group Entity Types
The system did not support `odrl:LogicalConstraint` with `odrl:or`, making it impossible to create policies for multiple entity types. Users had to create separate policies for each entity type.

### After: Single Group Constraint
```json
"odrl:refinement": {
  "@type": "odrl:Constraint",
  "odrl:leftOperand": "ngsi-ld:entityTypeGroup",
  "odrl:operator": "odrl:isAnyOf",
  "odrl:rightOperand": ["Schedule", "Incident", "DelayReport", "Train"]
}
```

## Example Policy: Transport Operations with Business Hours

This policy allows access to transport-related entities (Schedule, Incident, DelayReport, Train) during business hours (Monday–Friday, 6:00–21:00 UTC).

### Load Policy
```bash
curl -X PUT http://localhost:8081/policy/schedule_hours_policy \
  -H 'Content-Type: application/json' \
  -d '{
  "@context": {
    "dc": "http://purl.org/dc/elements/1.1/",
    "dct": "http://purl.org/dc/terms/",
    "owl": "http://www.w3.org/2002/07/owl#",
    "odrl": "http://www.w3.org/ns/odrl/2/",
    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
    "skos": "http://www.w3.org/2004/02/skos/core#",
    "ngsi-ld": "https://uri.etsi.org/ngsi-ld/"
  },
  "@type": "odrl:Policy",
  "@id": "https://mp-operation.org/policy/schedule-hours",
  "odrl:permission": {
    "odrl:assigner": { "@id": "https://www.mp-operation.org/" },
    "odrl:assignee": { "@id": "vc:any" },
    "odrl:target": {
      "@type": "odrl:AssetCollection",
      "odrl:source": "urn:asset",
      "odrl:refinement": {
        "@type": "odrl:Constraint",
        "odrl:leftOperand": "ngsi-ld:entityTypeGroup",
        "odrl:operator": "odrl:isAnyOf",
        "odrl:rightOperand": ["Schedule", "Incident", "DelayReport", "Train"]
      }
    },
    "odrl:action": { "@id": "odrl:read" },
    "odrl:constraint": [
      {
        "@type": "odrl:Constraint",
        "odrl:leftOperand": "odrl:dayOfWeek",
        "odrl:operator": "odrl:gteq",
        "odrl:rightOperand": { "@value": 0, "@type": "xsd:integer" }
      },
      {
        "@type": "odrl:Constraint",
        "odrl:leftOperand": "odrl:dayOfWeek",
        "odrl:operator": "odrl:lteq",
        "odrl:rightOperand": { "@value": 4, "@type": "xsd:integer" }
      },
      {
        "@type": "odrl:Constraint",
        "odrl:leftOperand": "odrl:hourOfDay",
        "odrl:operator": "odrl:gteq",
        "odrl:rightOperand": { "@value": 6, "@type": "xsd:integer" }
      },
      {
        "@type": "odrl:Constraint",
        "odrl:leftOperand": "odrl:hourOfDay",
        "odrl:operator": "odrl:lteq",
        "odrl:rightOperand": { "@value": 21, "@type": "xsd:integer" }
      }
    ]
  }
}'
```

### Test Policy Evaluation

**Test with allowed entity type:**
```bash
curl -X POST http://localhost:8181/ \
 -H "Content-Type: application/json" \
 -d '{
   "request": {
     "method": "GET",
     "path": "/ngsi-ld/v1/entities",
     "query": {
       "type": "Schedule"
     },
     "headers": {}
   }
 }'
```

**Test with disallowed entity type:**
```bash
curl -X POST http://localhost:8181/ \
 -H "Content-Type: application/json" \
 -d '{
   "request": {
     "method": "GET",
     "path": "/ngsi-ld/v1/entities",
     "query": {
       "type": "UnauthorizedEntity"
     },
     "headers": {}
   }
 }'
```

### Expected Results
- **`true`** → if executed Monday–Friday, 6:00–21:00 UTC, with entity type in ["Schedule", "Incident", "DelayReport", "Train"]
- **`false`** → otherwise

## Supported Operators

The `ngsi-ld:entityTypeGroup` operand has been tested with:

- **`odrl:isAnyOf`** → Check if entity type is in the allowed list ✅ **(Tested and working)**

*Note: Other array-compatible operators may work but have not been tested in this implementation. Only `odrl:isAnyOf` has been explicitly tested due to limitations in operand parsing logic for dynamic arrays.*

## Benefits

1. **New Functionality**: Enables multi-entity type policies that were previously not possible
2. **Simplified policies**: Single constraint instead of separate policies for each entity type
3. **Clear intent**: Explicit group-based access control

## Technical Notes

- Uses existing `entity_type` extraction logic for maximum compatibility
- Compatible with all NGSI-LD request patterns (path, body, query)
- Tested with `odrl:isAnyOf` operator (required for array-based validation)
- Entity type extraction follows NGSI-LD standards and URN patterns
- Does not work with `odrl:hasPart` (use `odrl:isAnyOf` instead)

## Related

This implementation addresses the need for multi-entity type access control in NGSI-LD-based data spaces and provides a foundation for domain-specific entity groupings in marketplace and IoT scenarios.