### PR TITLE
Ensure the verifiable credential type is an array

### DIFF
--- a/src/main/resources/rego/vc/leftOperand.rego
+++ b/src/main/resources/rego/vc/leftOperand.rego
@@ -15,5 +15,8 @@ role(verifiable_credential,organization_id) := r if {
 current_party(credential) := credential.issuer
 
 ## vc:type
-# the type(s) of the current credential
-types(verifiable_credential) := verifiable_credential.type
+# the type(s) of the current credential. Converted to array if string type.
+types(verifiable_credential) := result if {
+    is_array(verifiable_credential.type)
+    result = verifiable_credential.type
+} else := [verifiable_credential.type]


### PR DESCRIPTION
The `type` field of the tokens generated from SD-JWT verifiable credentials is a string instead of an array. To avoid errors when checking the type, it is converted into an array so that the rest of the flow and the existing policies keep working as expected.